### PR TITLE
Changing dependency to nom package instead of git url

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "author": "Jeff Ling <jeff@bench.co>",
   "license": "ISC",
   "dependencies": {
-    "namespace-css": "git://github.com/jeffling/namespace-css"
+    "namespace-css": "^0.1.3"
   }
 }


### PR DESCRIPTION
Having the git url with the git protocol is problematic inside my network. Hope you can accept it.
